### PR TITLE
Make sure URL does not behave unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- URIs are now parsed using `Addressable::URI#heuristic_parse` instead of `Addressable::URI#parse`
+  to more robustly handle URIs that can be specified in configuration. The coercion, contrary to
+  the default behaviour of `Addressable::URI#heuristic_parse` does not assume `http` as the default.
+  If the scheme is neither hinted at or specified in the URI, the scheme will be `nil` and the resulting
+  URI will be scheme-relative. If you prefer to assume a scheme, specify it explicitly,
+- `Types::URI` is now a type constructor, `Types.URI`. The constructor optionally accepts any
+  URI parsing hints `Addressable::URI#heuristic_parse` accepts.
 
 ## [0.1.0] - 2020-05-12
 ### Added

--- a/lib/fig/configurable/coercions.rb
+++ b/lib/fig/configurable/coercions.rb
@@ -8,6 +8,8 @@ module Fig
   module Coercions
     extend Dry::Types::Coercions
 
+    DUMMY_SCHEME = "DUMMY-SCHEME"
+
     # Coerces a string input into an array of strings, split by a separator
     def self.to_ary(input, separator = ",")
       return [] if input.nil?
@@ -34,11 +36,30 @@ module Fig
       input
     end
 
-    # Coerces
-    def self.to_uri(input)
+    # Coerces a string to an uri using `Addressable::URI#heuristic_parse` with optional hints
+    #
+    # NOTE: the default behaviour of `to_uri` differs crucially in one aspect
+    #       from `heuristic_parse` – `heuristic_parse` assumes the scheme if `http`
+    #       if it's neither hinted at nor specified in the URI string. `to_uri` just
+    #       assumes an empty schem, producing a scheme-relative URI. If you need
+    #       a concrete scheme, just hint it.
+    def self.to_uri(input, hints: {})
       return input if input.nil? || empty_str?(input)
 
-      Addressable::URI.parse(input)
+      # What's with this weird thing here? `heuristic_parse` always assumes that
+      # a URI, lacking an explicit scheme, is a `http` URI. We specify a dummy scheme
+      # as a hint if none is specified, so we can remove it and have a URI without
+      # scheme specified, not assume any scheme
+      parse_hints = hints.dup
+      parse_hints[:scheme] ||= DUMMY_SCHEME
+
+      result = Addressable::URI.heuristic_parse(input, parse_hints)
+
+      if result.scheme == DUMMY_SCHEME
+        result.scheme = nil
+      end
+
+      result
     end
   end
 end

--- a/lib/fig/configurable/types.rb
+++ b/lib/fig/configurable/types.rb
@@ -10,8 +10,6 @@ module Fig
     include ::Dry::Types.module
     include ::Dry::Types.module::Form
 
-    # A coercible URI
-    URI = Constructor(::Addressable::URI, Coercions.method(:to_uri))
     # A coercible symbol
     Symbol = Symbol.constructor(Coercions.method(:to_sym))
     # A coercible bool extended to admit enabled/disabled
@@ -26,6 +24,13 @@ module Fig
           coercion = proc { |value| Coercions.to_ary(value, separator) }
 
           super(member).constructor(coercion)
+        end
+
+        # A coercible URI; this is coerced
+        def URI(**hints)
+          coercion = proc { |value| Coercions.to_uri(value, :hints => hints) }
+
+          Constructor(::Addressable::URI, coercion)
         end
       end)
     end

--- a/spec/fixtures/configurable/coercions_spec.rb
+++ b/spec/fixtures/configurable/coercions_spec.rb
@@ -1,0 +1,24 @@
+require "fig/configurable/coercions"
+
+RSpec.describe Fig::Coercions do
+  describe "#to_uri coercion" do
+
+    it "a URI with no scheme will not assume a scheme when parsed" do
+      result = subject.to_uri("google.com")
+
+      expect(result.scheme).to be_nil
+    end
+
+    it "a URI with no scheme will assume the hinted scheme when parsed" do
+      result = subject.to_uri("google.com", :hints => { :scheme => "test" })
+
+      expect(result.scheme).to eq("test")
+    end
+
+    it "a URI with numbers parses correctly" do
+      result = subject.to_uri("421337.dkr.ecr.region.amazonaws.com")
+
+      expect(result.to_s).to eq("//421337.dkr.ecr.region.amazonaws.com")
+    end
+  end
+end


### PR DESCRIPTION
Currently parsing URIs is done with `Addressable::URI#parse` which treats URIs like `google.com` as… paths. `Addressable::URI#heuristic_parse` handles such cases correctly, but assumes the scheme is `http`, unless otherwise specified.

This PR switches parsing to `Addressable::URI#heuristic_parse` without assuming the `http` scheme if no scheme is hinted or specified in the URI – this will net you a `nil`-scheme protocol-relative URI such as `//google.com`.