### PR TITLE
Improve introspection of loader and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Configurations can now be protected from unwanted changes by calling `#finalize!` on them.
+- Configurations can now be protected from unwanted changes by calling `#finalize!` on them,
+- Loader instance can now be queried for the loaders it's configured with using `#loader`,
+- Configuration can now be converted to a hash using `to_h`.
 
 ## [0.1.0] - 2020-05-12
 ### Added

--- a/lib/fig/configurable.rb
+++ b/lib/fig/configurable.rb
@@ -97,5 +97,9 @@ module Fig
       settings.freeze
       freeze
     end
+
+    def to_h
+      settings.map { |setting| [setting.name, send(setting.getter_name)] }.to_h
+    end
   end
 end

--- a/lib/fig/loader/dsl.rb
+++ b/lib/fig/loader/dsl.rb
@@ -45,6 +45,11 @@ module Fig
         end
       end
 
+      # Get loaders
+      def loaders
+        @loaders
+      end
+
       # Load the configuration, returning a configuration object with the settings filled in
       def load!
         klass         = self.class._configuration_class


### PR DESCRIPTION
You can now query the loader instance to see what loaders are configured
using `#loaders` and confert the configuration to a hash using `to_h`.