### PR TITLE
Allow for a required-by-default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ end
 
 This will provide you with a getter method `#some_setting` and a setter method `#some_setting=`.
 
+By default all settings are optional, unless otherwise specified with a `required` modifier. You can change the default by calling the `required_by_default!` class macro:
+
+```ruby
+class SomeAppConfiguration
+  include Fig::Configurable
+
+  required_by_default!
+
+  setting(:some_setting)
+end
+```
+
 ### Configuration setting options
 
 A configuration setting has to be named using a symbol and has a few options to configure it's behaviour:
@@ -49,7 +61,7 @@ setting(:the_answer)                      # what is the name of the setting?    
   .required { |config| config.answered? } # is the setting required for the application to work? (optional)
 ```
 
-The setting is configured by calling methods on `Fig::SettingBuilder` instance returned by the `setting` macro. The `default` and `required` options can be called with either a static value as the single parameter, or a block computing the value on demand (the block will be provided with the instance of the config, should you require to derivce the value from some other setting).
+The setting is configured by calling methods on `Fig::SettingBuilder` instance returned by the `setting` macro. The `default` and `required` options can be called with either a static value as the single parameter, or a block computing the value on demand (the block will be provided with the instance of the config, should you require to derivce the value from some other setting). As a convenience for working with a required-by-default config a negated version of `required` is available as `optional`.
 
 See comments in the builder class or usage examples in the tests for further details.
 

--- a/lib/fig/configurable/setting_builder.rb
+++ b/lib/fig/configurable/setting_builder.rb
@@ -4,8 +4,10 @@ module Fig
   # A builder class for a setting descriptor
   class SettingBuilder
     # Setting with a name, this is required
-    def name(name)
+    def name(name, defaults: {})
       @name = name
+
+      @required = defaults[:required] if defaults.has_key?(:required)
 
       self
     end
@@ -51,15 +53,26 @@ module Fig
       self
     end
 
+    # A convenient alias for a negated version of `required` if you're working with
+    # a required-by-default config. To wit, it will make a value non-required when called
+    # or when the block returns true.
+    def optional(optional = true, &block)
+      if block_given?
+        required(!optional) { !block.call() }
+      else
+        required(!optional)
+      end
+    end
+
     # Builds a setting descriptor
     def build!
       Setting.new(
-        name:             @name,
-        type:             @type,
-        default:          @default,
-        compute_default:  @compute_default,
-        required:         @required,
-        compute_required: @compute_required
+        :name             => @name,
+        :type             => @type,
+        :default          => @default,
+        :compute_default  => @compute_default,
+        :required         => @required,
+        :compute_required => @compute_required
       )
     end
   end

--- a/lib/fig/configurable/types.rb
+++ b/lib/fig/configurable/types.rb
@@ -17,7 +17,7 @@ module Fig
     # A coercible bool extended to admit enabled/disabled
     #
     # NOTE: it doesn't work without safe, but I'm unsure why as dry-types doesn't seem to explain itself.
-    #       My hunch is it has to do with the fact that Bool is defined as an ADT of True | False, but might be wronf
+    #       My hunch is it has to do with the fact that Bool is defined as an ADT of True | False, but might be wrong
     Bool = ::Dry::Types.module::Form::Bool.constructor(Coercions.method(:enablement_to_bool)).safe
     class << self
       prepend(Module.new do

--- a/spec/fixtures/configuration_fixtures.rb
+++ b/spec/fixtures/configuration_fixtures.rb
@@ -50,4 +50,13 @@ module ConfigurationFixtures
     setting(:with_default).default(13.37)
     setting(:with_computed_default).default { |config| config.with_default * 2 }
   end
+
+  class RequiredByDefault
+    include Fig::Configurable
+
+    required_by_default!
+
+    setting(:required)
+    setting(:overriden_to_optional).optional
+  end
 end

--- a/spec/lib/fig/configurable_spec.rb
+++ b/spec/lib/fig/configurable_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Fig::Configurable do
       expect(subject).to respond_to(:required_by_default!)
     end
 
-    it "provides the `required_by_default!` macro" do
+    it "provides the `optional_by_default!` macro" do
       expect(subject).to respond_to(:optional_by_default!)
     end
 

--- a/spec/lib/fig/configurable_spec.rb
+++ b/spec/lib/fig/configurable_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe Fig::Configurable do
       expect(subject).to respond_to(:setting)
     end
 
+    it "provides the `required_by_default!` macro" do
+      expect(subject).to respond_to(:required_by_default!)
+    end
+
+    it "provides the `required_by_default!` macro" do
+      expect(subject).to respond_to(:optional_by_default!)
+    end
+
     it "provides the `settings` method on the class" do
       expect(subject).to respond_to(:settings)
     end
@@ -163,6 +171,25 @@ RSpec.describe Fig::Configurable do
         expect(subject.settings.map(&:name)).to contain_exactly(:test)
       end
     end
+
+    describe "#required_by_default!" do
+      subject { ConfigurationFixtures::RequiredByDefault.new }
+
+      context "validating configuration" do
+        it "fails if the value of the required setting is missing" do
+          expect { subject.validate! }.to raise_error(Fig::Errors::InvalidConfiguration) do |error|
+            expect(error.invalid_settings).to     include(:required)
+            expect(error.invalid_settings).not_to include(:overriden_to_optional)
+          end
+        end
+
+        it "passes if the value of the required setting is present" do
+          subject.required = "Gnawing Hunger"
+
+          expect { subject.validate! }.not_to raise_error
+        end
+      end
+    end
   end
 
   describe "instance methods" do
@@ -198,7 +225,7 @@ RSpec.describe Fig::Configurable do
           expect { subject.validate! }.to raise_error(Fig::Errors::InvalidConfiguration)
         end
 
-        it "the raised exception contains infomration on which settings are invalid" do
+        it "the raised exception contains information on which settings are invalid" do
           subject.numerics = "insert some clever popculture reference here"
 
           expect { subject.validate! }.to raise_error do |error|


### PR DESCRIPTION
The developer can now specify if the settings should be optional or required by default.